### PR TITLE
Make RadioGroup the only tabbable element by using aria-activedescendant

### DIFF
--- a/src/components/DeviceTypeControl/DeviceTypeControl.js
+++ b/src/components/DeviceTypeControl/DeviceTypeControl.js
@@ -11,16 +11,11 @@ import {
 export default function DeviceTypeControl() {
 	const radio = useRadioState({
 		state: 'desktop',
+		unstable_virtual: true,
 	});
 
 	return (
-		<RadioGroup
-			{...radio}
-			aria-label="device-type"
-			as={ContainerView}
-			focusable={true}
-			unstable_virtual={true}
-		>
+		<RadioGroup {...radio} aria-label="device-type" as={ContainerView}>
 			<Backdrop {...radio} />
 			<RadioButton {...radio} value="mobile" label="Mobile" isFirst />
 			<RadioButton {...radio} value="tablet" label="Tablet" />

--- a/src/components/DeviceTypeControl/DeviceTypeControl.style.js
+++ b/src/components/DeviceTypeControl/DeviceTypeControl.style.js
@@ -10,7 +10,7 @@ export const ContainerView = styled(View)`
 	position: relative;
 
 	&:focus {
-		outline: none;
+		// outline: none;
 	}
 `;
 


### PR DESCRIPTION
Commented out `outline: none` from css just to show the focus style, but you may want to have a different style.

![May-17-2020 16-26-08](https://user-images.githubusercontent.com/3068563/82157995-4da00500-985b-11ea-8b78-8952b3d5e73c.gif)
